### PR TITLE
fix: missing/broken links in ISSUE_TEMPLATES

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,20 +1,21 @@
 name: 🪲 Bug Report
 description: Report those pesky bugs!
-title: "[Bug]: "
-labels: ["needs triage"]
-projects: ["SpaceHub"]
+title: '[Bug]: '
+labels: ['needs triage']
+projects: ['SpaceHub']
 
 body:
-
   - type: checkboxes
     attributes:
       label: IMPORTANT!
       description: Please review these items before submitting an issue to ensure you’ve completed the necessary steps.
       options:
-        - label: I'm using the latest version of Docusaurus.
-          required: true
         - label: I have read the Guidelines in [reporting bugs](https://mkeithx.pages.dev/community/issue/report).
-        - label: I have perform [basic troubleshooting](https://mkeithx.pages.dev/community/issue/installation#troubleshooting) (if applicable).
+          required: true
+        - label: I'm certain that I have [configured it correctly](https://mkeithx.pages.dev/community/issue/style-guide/troubleshoot).
+          required: true
+        - label: I have performed [basic troubleshooting]https://mkeithx.pages.dev/community/issue/style-guide/troubleshoot) (if applicable).
+          required: true
         - label: I'd be willing to address this issue myself.
 
   - type: textarea
@@ -23,7 +24,6 @@ body:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: "A bug happened when "
     validations:
       required: true
 
@@ -44,7 +44,7 @@ body:
     id: browsers
     attributes:
       label: What browsers are you seeing the problem on?
-      multiple: true
+      multiple: false
       options:
         - Firefox
         - Chrome
@@ -52,12 +52,12 @@ body:
         - Microsoft Edge
         - Brave
         - DuckDuck Go
-  
+
   - type: dropdown
     id: device
     attributes:
       label: Device type.
-      multiple: true
+      multiple: false
       options:
         - Mobile
         - Desktop

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: 📒 Documentation
 description: Report an issue related to documentation
-title: "[Docs]: "
-labels: ["needs triage"]
+title: '[Docs]: '
+labels: ['needs triage','documentation']
 
 body:
   - type: markdown
@@ -9,15 +9,7 @@ body:
       value: |
         ## Important!
 
-        Use this template to report various documentation-related issues.
-        If documentation issues arise, consider if it’s a documentation or code problem. For code issues, use the "bug" template.
-
-        Pull requests are generally accepted if:
-        - Relevant to many users
-        - Not about external tooling
-        - Not documented elsewhere or hard to find
-
-        You may submit a pull request directly if criteria are met; otherwise, issues are welcome.
+        Use this template to report documentation-related issues. Make sure that you read the [Guidelines](https://mkeithx.pages.dev/community/issue/report#docs) before submitting.
 
   - type: dropdown
     id: issue
@@ -30,7 +22,7 @@ body:
         - Elaboration needed
         - Outdated or incorrect information
         - Formatting or readability improvement
-        - Others
+        - Other
     validations:
       required: true
 
@@ -40,15 +32,17 @@ body:
       label: Description
       description: A clear description of the issue.
       placeholder: Tell us what you see!
-      value: "Describe the issue"
+      value: 'Describe the issue'
     validations:
       required: true
 
   - type: checkboxes
+    id: terms
     attributes:
-      label: Have you read the Contributing Guidelines on [reporting issues?](https://mkeithx.pages.dev/community/report-an-issue)
+      label: Code of Conduct
+      description: By submitting, you agree to our [Code of Conduct](https://github.com/mkeithX/mkeithx.github.io/blob/main/CONTRIBUTING.md)
       options:
-        - label: I have read the [Code of Conduct](https://github.com/mkeithX/mkeithx.github.io/blob/main/CONTRIBUTING.md).
+        - label: I agree to follow this project's Code of Conduct.
           required: true
 
   - type: checkboxes
@@ -58,3 +52,4 @@ body:
         If you can contribute, check the box to indicate you're working on it. Please submit a pull request within 7 days.
       options:
         - label: I'd be willing to address this documentation request myself.
+          required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -14,8 +14,8 @@ body:
   - type: dropdown
     id: issue
     attributes:
-      label: Issue category
-      description: What's the issue about?
+      label: What's this about?
+      description: Help us categorize this issue/request.
       multiple: false
       options:
         - Undocumented API
@@ -31,8 +31,7 @@ body:
     attributes:
       label: Description
       description: A clear description of the issue.
-      placeholder: Tell us what you see!
-      value: 'Describe the issue'
+      placeholder: Clearly describe the issue/request in detail.
     validations:
       required: true
 


### PR DESCRIPTION
### Motivation
This PR addresses two main issues:

1. Broken Links: Fixes missing and broken links in the checklist.

2. Dropdown Menu: Ensures that options in the dropdown menu are required and limited to one selection



### Related Issues/PRs
- [Issue#182](https://github.com/mkeithX/mkeithx.github.io/issues/182)


### Checklist
- [x] I have read the Contributing Guidelines on [Pull Request](https://github.com/mkeithX/mkeithx.github.io/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have tested the changes locally.
- [x] I have ensured that all existing tests pass.
- [x] I have added necessary documentation (if applicable).
